### PR TITLE
Add support for all material design heading sizes

### DIFF
--- a/qfc-dark.css
+++ b/qfc-dark.css
@@ -23,24 +23,58 @@ body {
 }
 
 .qfc-container h1,h2,h3,h4,h5,h6 {
-  font-size: 30px;
   text-decoration: none;
   position: relative;
-  margin: 50px 0;
+  //margin: 50px 0;
+  font-weight: 400;
+  margin: 0;
 }
 
-.qfc-container h1:after,
-.qfc-container h2:after,
-.qfc-container h3:after,
-.qfc-container h4:after,
-.qfc-container h5:after,
-.qfc-container h6:after {
+.qfc-container h1 {
+  font-size: 112px;
+  font-weight: 300;
+  letter-spacing: -5px;
+  line-height: 128px;
+}
+
+.qfc-container h2 {
+  font-size: 56px;
+  line-height: 64px;
+}
+
+.qfc-container h3 {
+  font-size: 45px;
+  line-height: 64px;
+}
+
+.qfc-container h4 {
+  font-size: 34px;
+  line-height: 52px;
+}
+
+.qfc-container h5 {
+  font-size: 24px;
+  line-height: 44px;
+}
+
+.qfc-container h6 {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 44px;
+}
+
+.qfc-container h1:not(.no-underline):after,
+.qfc-container h2:not(.no-underline):after,
+.qfc-container h3:not(.no-underline):after,
+.qfc-container h4:not(.no-underline):after,
+.qfc-container h5:not(.no-underline):after,
+.qfc-container h6:not(.no-underline):after {
   content: '';
-  margin-top: 31px;
+  position: relative;
+  display: block;
+  bottom: 0;
+  margin-bottom: 30px;
   width: 100%;
-  position: absolute;
-  left: 0;
-  bottom: -13px;
   border: 3px solid var(--form-theme-color);
 }
 

--- a/qfc-dark.css
+++ b/qfc-dark.css
@@ -25,9 +25,8 @@ body {
 .qfc-container h1,h2,h3,h4,h5,h6 {
   text-decoration: none;
   position: relative;
-  //margin: 50px 0;
+  margin: 50px 0 0;
   font-weight: 400;
-  margin: 0;
 }
 
 .qfc-container h1 {
@@ -76,6 +75,15 @@ body {
   margin-bottom: 30px;
   width: 100%;
   border: 3px solid var(--form-theme-color);
+}
+
+.qfc-container .no-underline + h1,
+.qfc-container .no-underline + h2,
+.qfc-container .no-underline + h3,
+.qfc-container .no-underline + h4,
+.qfc-container .no-underline + h5,
+.qfc-container .no-underline + h6 {
+  margin-top: 0;
 }
 
 .qfc-container input[type="checkbox"] {

--- a/qfc-dark.css
+++ b/qfc-dark.css
@@ -72,7 +72,7 @@ body {
   position: relative;
   display: block;
   bottom: 0;
-  margin-bottom: 30px;
+  margin-bottom: 31px;
   width: 100%;
   border: 3px solid var(--form-theme-color);
 }

--- a/qfc-light.css
+++ b/qfc-light.css
@@ -22,26 +22,68 @@ body {
   margin-top: 30px;
 }
 
-.qfc-container h1,h2,h3,h4,h5,h6 {
-  font-size: 30px;
-  text-decoration: none;
-  position: relative;
-  margin: 50px 0;
+.qfc-container h1 {
+  font-size: 112px;
+  font-weight: 300;
+  letter-spacing: -5px;
+  line-height: 128px;
 }
 
-.qfc-container h1:after,
-.qfc-container h2:after,
-.qfc-container h3:after,
-.qfc-container h4:after,
-.qfc-container h5:after,
-.qfc-container h6:after {
+.qfc-container h2 {
+  font-size: 56px;
+  line-height: 64px;
+}
+
+.qfc-container h3 {
+  font-size: 45px;
+  line-height: 64px;
+}
+
+.qfc-container h4 {
+  font-size: 34px;
+  line-height: 52px;
+}
+
+.qfc-container h5 {
+  font-size: 24px;
+  line-height: 44px;
+}
+
+.qfc-container h6 {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 44px;
+}
+
+.qfc-container h1,h2,h3,h4,h5,h6 {
+  text-decoration: none;
+  position: relative;
+  margin: 50px 0 0;
+  font-weight: 400;
+}
+
+.qfc-container h1:not(.no-underline):after,
+.qfc-container h2:not(.no-underline):after,
+.qfc-container h3:not(.no-underline):after,
+.qfc-container h4:not(.no-underline):after,
+.qfc-container h5:not(.no-underline):after,
+.qfc-container h6:not(.no-underline):after {
   content: '';
-  margin-top: 31px;
+  position: relative;
+  display: block;
+  bottom: 0;
+  margin-bottom: 31px;
   width: 100%;
-  position: absolute;
-  left: 0;
-  bottom: -13px;
   border: 3px solid var(--form-theme-color);
+}
+
+.qfc-container .no-underline + h1,
+.qfc-container .no-underline + h2,
+.qfc-container .no-underline + h3,
+.qfc-container .no-underline + h4,
+.qfc-container .no-underline + h5,
+.qfc-container .no-underline + h6 {
+  margin-top: 0;
 }
 
 .qfc-container input[type="checkbox"] {


### PR DESCRIPTION
https://github.com/siwalikm/quick-form-css/issues/2

This adds support for Material Design heading sizes from `h1` down to `h6`, as translated to CSS by http://brm.io/material-design-type/

By default, each of these sizes renders with the bottom border (to allow for backwards compatibility). 
Positioning of the bottom border has been tweaked to make it sit nicely with every text size.

If it's desired to have a block of different size titles (eg. title and subtitle) together (before the border), the earlier ones should have the `.no-underline` class added. This gives a nice top margin and an appropriately margined bottom-border for each titles block. The line height is set so titles space against each other appropriately.

Examples:

With `<h2>Form Title</h2>`

![h2](https://user-images.githubusercontent.com/2221991/31582854-8353e60e-b1da-11e7-948b-1ab9a02c262f.png)

With
```
<h2 class="no-underline">Form Title</h2>
<h3>Form subtitle</h3>
```

![subtitle](https://user-images.githubusercontent.com/2221991/31582857-93b7e4d2-b1da-11e7-9bad-9d02fbf0e230.png)

With
```
<h1>Form title</h1>
...
<h6>Form title</h6>
```
(I can't imagine why you'd ever actually do this, but...)

![titles_all](https://user-images.githubusercontent.com/2221991/31582867-b9b838b2-b1da-11e7-880c-a0783e225498.png)
